### PR TITLE
feat: 비밀번호 재설정 페이지 퍼블리싱

### DIFF
--- a/src/app/(routes)/resetPassword/page.tsx
+++ b/src/app/(routes)/resetPassword/page.tsx
@@ -43,13 +43,25 @@ export default function ResetPassword() {
   };
 
   return (
-    <div>
-      <form onSubmit={handleSubmit(onSubmit)}>
+    <div
+      className={`mt-6 flex flex-col items-center md:mt-25-custom lg:mt-35-custom ${hasErrors ? 'gap-6.5-custom md:gap-11.25-custom lg:gap-12.25-custom' : 'gap-6.25-custom md:gap-12.25-custom lg:gap-12'} `}
+    >
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        className="flex w-85.75-custom flex-col gap-10 md:w-115-custom lg:w-115-custom"
+      >
         <div>
-          <p>비밀번호 재설정</p>
-          <div>
-            <div>
-              <label htmlFor="password">새 비밀번호</label>
+          <p className="text-2xl-medium md:text-2xl-medium mb-6 text-center text-text-primary md:mb-20 lg:mb-20 lg:text-4xl">
+            비밀번호 재설정
+          </p>
+          <div className="flex flex-col gap-6">
+            <div className="flex flex-col gap-3">
+              <label
+                htmlFor="password"
+                className="text-lg-medium text-text-primary"
+              >
+                새 비밀번호
+              </label>
               <FormField
                 id="newPassword"
                 type={showNewPassword ? 'text' : 'password'}
@@ -60,8 +72,13 @@ export default function ResetPassword() {
                 error={errors.newPassword}
               />
             </div>
-            <div>
-              <label htmlFor="password">비밀번호 확인</label>
+            <div className="flex flex-col gap-3">
+              <label
+                htmlFor="password"
+                className="text-lg-medium text-text-primary"
+              >
+                비밀번호 확인
+              </label>
               <FormField
                 id="newPasswordConfirm"
                 type={showNewPasswordConfirm ? 'text' : 'password'}
@@ -76,8 +93,14 @@ export default function ResetPassword() {
             </div>
           </div>
         </div>
-        <div>
-          <button type="submit" disabled={isSubmitting || !isValid}>
+        <div className="flex flex-col gap-6">
+          <button
+            type="submit"
+            disabled={isSubmitting || !isValid}
+            className={`text-lg-semibold rounded-xl bg-brand-primary py-3.5 text-text-primary ${
+              !isValid ? 'cursor-not-allowed bg-text-default opacity-50' : ''
+            }`}
+          >
             재설정
           </button>
         </div>

--- a/src/app/(routes)/resetPassword/page.tsx
+++ b/src/app/(routes)/resetPassword/page.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { RESET_PASSWORD_SCHEMA } from '@/utils/schema';
+import FormField from '@/components/signup/FormField';
+import visibility_on from '@/assets/icons/visibility_on.svg';
+import visibility_off from '@/assets/icons/visibility_off.svg';
+
+type ResetPasswordFormData = {
+  newPassword: string;
+  newPasswordConfirm: string;
+};
+
+export default function ResetPassword() {
+  const {
+    register,
+    handleSubmit,
+    formState: { isSubmitting, isValid, errors },
+  } = useForm<ResetPasswordFormData>({
+    resolver: yupResolver(RESET_PASSWORD_SCHEMA),
+    mode: 'onChange',
+  });
+
+  // 비밀번호 표시
+  const [showNewPassword, setShowNewPassword] = useState(false);
+  const toggleNewPasswordVisibility = () => {
+    setShowNewPassword(!showNewPassword);
+  };
+
+  // 비밀번호 확인 표시
+  const [showNewPasswordConfirm, setShowNewPasswordConfirm] = useState(false);
+  const toggleNewPasswordConfirmVisibility = () => {
+    setShowNewPasswordConfirm(!showNewPasswordConfirm);
+  };
+
+  // error 메시지 여부 확인
+  const hasErrors = Object.keys(errors).length > 0;
+
+  const onSubmit = (data: ResetPasswordFormData) => {
+    console.log(data);
+  };
+
+  return (
+    <div>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <div>
+          <p>비밀번호 재설정</p>
+          <div>
+            <div>
+              <label htmlFor="password">새 비밀번호</label>
+              <FormField
+                id="newPassword"
+                type={showNewPassword ? 'text' : 'password'}
+                placeholder="비밀번호 (숫자, 영문, 특수문자, 8자 이상)를 입력해주세요."
+                trailingIcon={showNewPassword ? visibility_off : visibility_on}
+                onIconClick={toggleNewPasswordVisibility}
+                register={register}
+                error={errors.newPassword}
+              />
+            </div>
+            <div>
+              <label htmlFor="password">비밀번호 확인</label>
+              <FormField
+                id="newPasswordConfirm"
+                type={showNewPasswordConfirm ? 'text' : 'password'}
+                placeholder="새 비밀번호를 다시 한번 입력해주세요."
+                trailingIcon={
+                  showNewPasswordConfirm ? visibility_off : visibility_on
+                }
+                onIconClick={toggleNewPasswordConfirmVisibility}
+                register={register}
+                error={errors.newPasswordConfirm}
+              />
+            </div>
+          </div>
+        </div>
+        <div>
+          <button type="submit" disabled={isSubmitting || !isValid}>
+            재설정
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import './styles/globals.css';
+import '@/styles/globals.css';
 
 export default function Page() {
   return (
@@ -8,4 +8,3 @@ export default function Page() {
     </>
   );
 }
-

--- a/src/components/signup/FormField.tsx
+++ b/src/components/signup/FormField.tsx
@@ -30,7 +30,7 @@ const FormField = ({
           placeholder={placeholder}
           autoComplete="off"
           {...register(id)}
-          className={`placeholder:text-lg-regular h-12 w-85.75-custom rounded-xl border border-solid border-border-tertiary bg-background-secondary px-4 py-3.625-custom text-text-primary placeholder:text-text-default focus:outline-none md:w-115-custom lg:w-115-custom ${
+          className={`placeholder:text-md-regular md:placeholder:text-lg-regular lg:placeholder:text-lg-regular h-12 w-85.75-custom rounded-xl border border-solid border-border-tertiary bg-background-secondary px-4 py-3.625-custom text-text-primary placeholder:text-text-default focus:outline-none md:w-115-custom lg:w-115-custom ${
             error
               ? 'border-status-danger ring-1 ring-status-danger'
               : 'focus:border-status-brand focus:ring-1 focus:ring-status-brand'

--- a/src/components/signup/FormField.tsx
+++ b/src/components/signup/FormField.tsx
@@ -37,14 +37,19 @@ const FormField = ({
           } `}
         />
         {trailingIcon && (
-          <Image
-            src={trailingIcon}
-            width={24}
-            height={24}
-            onClick={onIconClick}
-            alt="비밀번호 표시 아이콘"
-            className="absolute right-4 top-1/2 -translate-y-1/2 transform cursor-pointer"
-          />
+          <>
+            <Image
+              src={trailingIcon}
+              width={24}
+              height={24}
+              onClick={onIconClick}
+              alt="비밀번호 표시 아이콘"
+              className="absolute right-4 top-1/2 z-10 -translate-y-1/2 transform cursor-pointer"
+            />
+            <div className="bg-custom-gradient w-9.5-custom absolute right-4 top-1/2 z-0 block h-6 -translate-y-1/2 transform md:hidden lg:hidden">
+              {' '}
+            </div>
+          </>
         )}
       </div>
       {error && (

--- a/src/utils/schema.tsx
+++ b/src/utils/schema.tsx
@@ -45,3 +45,22 @@ export const SIGNUP_SCHEMA = COMMON_SCHEMA.concat(
       ),
   }),
 );
+
+// 비밀번호 재설정 스키마
+export const RESET_PASSWORD_SCHEMA = yup.object().shape({
+  newPassword: yup
+    .string()
+    .required('비밀번호를 입력해주세요.')
+    .min(8, '비밀번호는 최소 8자 이상입니다.')
+    .matches(
+      /^[a-zA-Z0-9!@#$%^*+=-]+$/,
+      '숫자, 영문, 특수문자로만 가능합니다.',
+    ),
+  newPasswordConfirm: yup
+    .string()
+    .required('비밀번호를 입력해주세요.')
+    .min(8, '비밀번호는 최소 8자 이상입니다.')
+    .test('password-match', '비밀번호가 일치하지 않습니다.', function (value) {
+      return value === this.parent.newPassword || !value;
+    }),
+});

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -110,6 +110,7 @@ const config: Config = {
       width: {
         '115-custom': '460px',
         '85.75-custom': '343px',
+        '9.5-custom': '38px',
       },
       gap: {
         '12.25-custom': '49px',
@@ -117,8 +118,6 @@ const config: Config = {
         '10.5-custom': '42px',
         '6.75-custom': '27px',
         '6.5-custom': '26px',
-        '10.5-custom': '42px',
-        '6.75-custom': '27px',
         '6.25-custom': '25px',
       },
       padding: {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -128,6 +128,10 @@ const config: Config = {
         '30-custom': '120px',
         '35-custom': '140px',
       },
+      backgroundImage: {
+        'custom-gradient':
+          'linear-gradient(270deg, #1E293B 0%, #1E293B 62.05%, rgba(30, 41, 59, 0) 127.63%)',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 퍼블리싱

### 🎉작업 내용
#### 수정 내역
1. 오류 수정: `src/app/page.tsx` 절대경로로 수정
2. `tailwind.config.js` 수정
    - gap 중복값 제거
    -  width에 '9.5-custom' 및 커스텀 배경 그라디언트 추가
3. `FormField` 컴포넌트 모바일 사이즈일 때 placeholder 폰트 크기 수정
    - 기존: 모든 사이즈에서 16px
    - 변경: 모바일 사이즈에서는 14px, 나머지는 16px 적용
    - **기존 로그인, 회원가입 페이지에도 적용됩니다.**
4. `FormField` 컴포넌트 모바일 사이즈일 때, 비밀번호 표시/숨기기 아이콘 뒤에 그라디언트 배경 적용
    - tablet, desktop에서는 배경 숨김
      ![image](https://github.com/user-attachments/assets/0fd894b5-1ed9-417e-9b5d-54ac7c1e4d33)
    - **기존 로그인, 회원가입 페이지에도 적용됩니다.**

#### 작업 내역
1. 비밀번호 재설정 관련 스키마 추가
2. 유효성 검사: 버튼 포함
3. 반응형 구현

### 🖼️이미지 첨부
1. 반응형
    ![240906_비밀번호재설정_반응형](https://github.com/user-attachments/assets/b738ebd2-045b-4722-8c59-5b21d77e1121)
2. 유효성 검사
    ![240906_비밀번호재설정_유효성검사](https://github.com/user-attachments/assets/2bc63eeb-b1ea-450b-b7b2-ac8ff55a7c26)

### 🔨발생한 에러
- `src/app/page.tsx`에서 `globals.css`를 상대경로로 import 할 때 오류 발생
   ![image](https://github.com/user-attachments/assets/af8b0275-30af-4a83-b114-5ef94d93a6f3)

### 🔊전달 내용
- 모달 제외 퍼블리싱 완료
- [회원가입, 로그인 페이지](https://codeit.notion.site/Coworkers-e093f1edc92843b7867782055918196b)와 [비밀번호 재설정 페이지](https://www.figma.com/design/d5ogtLVSv1m7e8kx1Lfamy/%5BCCC%5DCowokers?node-id=52-1213&node-type=CANVAS&t=He69qNMvQVtlevbz-0)의 유효성 검사 규칙이 다릅니다.
  ```
  회원가입 페이지 비밀번호 유효성 규칙
    1. 8자 미만 👉 비밀번호는 최소 8자 이상입니다.
    2. 숫자, 영문, 특수문자 이외 문자 포함 시 👉 비밀번호는 숫자, 영문, 특수문자로만 가능합니다.
   
  비밀번호 재설정 페이지 input placeholder 
    - 비밀번호 (영문, 숫자 포함, 12자 이내)를 입력해주세요.
  ```
  일단은 회원가입, 로그인 페이지에 맞춰서 구현해놓은 상태입니다.
  **규칙 변경이 필요할 경우 피드백 부탁드려요-!**
