### PR TITLE
refactor: 이메일 전송 후 토스트, 모달 닫기 추가

### DIFF
--- a/src/components/modal/ModalTwoButtonPassword.tsx
+++ b/src/components/modal/ModalTwoButtonPassword.tsx
@@ -107,7 +107,7 @@ const ModalTwoButtonPassword = ({
           className="px-auto py-auto w-[136px] rounded-xl border border-brand-primary bg-brand-primary"
           onClick={handleSubmit(handleChangePwd)}
         >
-          링크 보내기
+          변경하기
         </button>
       </div>
     </div>

--- a/src/components/modal/ModalWrapper.tsx
+++ b/src/components/modal/ModalWrapper.tsx
@@ -36,7 +36,7 @@ export default function ModalWrapper({ children }: ModalWrapperProps) {
 
   return (
     <div
-      className="fixed inset-0 flex items-end justify-center bg-black bg-opacity-50 md:items-center lg:items-center"
+      className="fixed inset-0 z-50 flex items-end justify-center bg-black bg-opacity-50 md:items-center lg:items-center"
       onClick={handleClickOutside}
     >
       <div

--- a/src/components/modal/ResetPwdModal.tsx
+++ b/src/components/modal/ResetPwdModal.tsx
@@ -47,6 +47,10 @@ export default function ResetPwdModal({
       );
       if (result.status === 200) {
         openToast('이메일을 전송했습니다.', 'success');
+        setTimeout(() => {
+          closeModal?.();
+          closeToast();
+        }, 1500);
       }
     } catch (error: any) {
       if (error.response && error.response.status === 400) {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

<br/>

### 🎉작업 내용
- 비밀번호 재설정을 위한 이메일 전송 모달에서
  이메일 전송 후, 토스트 및 모달 자동으로 닫힘 기능 추가
- 계정 설정 페이지 내 비밀번호 변경하기 모달에서
  오타 수정: 링크 보내기 > 변경하기

<br/>

### 🖼️이미지 첨부

<br/>

### 🔨발생한 에러

<br/>